### PR TITLE
Fixed issue where UI State was incorrect (#109)

### DIFF
--- a/Sources/JoinVoiceChannelAction.h
+++ b/Sources/JoinVoiceChannelAction.h
@@ -26,7 +26,7 @@ class JoinVoiceChannelAction final : public DiscordESDAction {
   }
 
   virtual int GetDesiredState(const DiscordClient& client) override final {
-    return 0;
+    return client.getCurrentVoiceChannel()->channel_id == mChannelId ? 1 : 0;
   }
 
   virtual void Reconnected(DiscordClient& client) override final {


### PR DESCRIPTION
If you have multiple pages or folders, the state of a channel was previously always set as 0 by default. 

Now we check to make sure the user is in the applicable channel.